### PR TITLE
subnets: fix logic to target dev subnets only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_subnet" "subnet" {
   address_prefixes                  = each.value["address_prefixes"]
   service_endpoints                 = each.value["service_endpoints"]
   private_endpoint_network_policies = "Enabled"
-  default_outbound_access_enabled   = each.value["default_outbound_access_enabled"]  && startswith(var.vnet_name, "d-")
+  default_outbound_access_enabled   = each.value["default_outbound_access_enabled"]  && startswith(local.vnet_name, "d-")
 
   dynamic "delegation" {
     for_each = each.value["delegation"] == null ? {} : each.value["delegation"]


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
var.vnet_name is often null. startswith(null,"d-") seems to be true.
```
